### PR TITLE
Scope text snippets more appropriately

### DIFF
--- a/snippets/language-text.cson
+++ b/snippets/language-text.cson
@@ -1,4 +1,4 @@
-'*':
+'.source.gfm, .comment, .string, .text':
   'Copyright Notice':
     'prefix': 'legal'
     'body': 'Copyright (c) ${1:2015} ${2:Copyright Holder} ${3:All Rights Reserved.}$4'


### PR DESCRIPTION
Currently these text snippets will appear anywhere in the source code, when they should really be scoped to text regions.

This is useful because otherwise snippets appear in weird places, such as for YAML keys.

Related question: Is there a way to say the text is a direct child of this node. E.g. Direct text under `.source`?
