### PR TITLE
Update year in legal snippet

### DIFF
--- a/snippets/language-text.cson
+++ b/snippets/language-text.cson
@@ -1,7 +1,7 @@
-'*':
+'.source.text':
   'Copyright Notice':
     'prefix': 'legal'
-    'body': 'Copyright (c) ${1:2016} ${2:Copyright Holder} ${3:All Rights Reserved.}$4'
+    'body': 'Copyright (c) ${1:2017} ${2:Copyright Holder} ${3:All Rights Reserved.}$4'
   'Lorem ipsum':
     'prefix': 'lorem'
     'body': 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'

--- a/snippets/language-text.cson
+++ b/snippets/language-text.cson
@@ -1,4 +1,4 @@
-'.source.text':
+'.source.gfm, .comment, .string, .text':
   'Copyright Notice':
     'prefix': 'legal'
     'body': 'Copyright (c) ${1:2017} ${2:Copyright Holder} ${3:All Rights Reserved.}$4'


### PR DESCRIPTION
I changed the scope of the two snippets to non-code contexts only. This will benefit anyone who writes 'float: left' in CSS or 'lea' in assembly. I also updated the year to 2017.